### PR TITLE
🔧  Set publishing target to Flexbase

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "persona-node-client",
+  "name": "@flexbase/persona-node-client",
   "version": "0.1.0",
   "description": "Node.js Client for Persona API",
   "keywords": [


### PR DESCRIPTION
We needed to update the publishing target to Flexbase where things are
now starting to collect.