### PR TITLE
🧼  Needed to drop logging used in testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/persona-node-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Node.js Client for Persona API",
   "keywords": [
     "withpersona.com",

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,6 @@ export class Persona {
     if (query) {
       Object.keys(query).forEach(k => {
         if (something(query![k])) {
-          console.log('QUERY', k, query![k])
           url.searchParams.append(k, query![k].toString())
         }
       })


### PR DESCRIPTION
There is no reason to keep the logging that was needed in testing, as
it's all fixed up now, and we don't want to make a lot of noise.