### PR TITLE
🧪  Add feedback on Report Errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flexbase/persona-node-client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Node.js Client for Persona API",
   "keywords": [
     "withpersona.com",

--- a/src/report/index.ts
+++ b/src/report/index.ts
@@ -248,6 +248,7 @@ export class ReportApi {
     error?: PersonaError,
     details?: PersonaCallDetails,
     included?: PersonaIncluded,
+    request?: object | object[],
   }> {
     const resp = await this.client.fire('POST', 'reports', undefined, undefined, body)
     if ((resp?.response?.status >= 400) || !isEmpty(resp?.payload?.errors)) {
@@ -255,6 +256,7 @@ export class ReportApi {
         success: false,
         error: { type: 'persona', causes: resp?.payload?.errors },
         details: resp?.details,
+        request: body,
       } as any
       if (synchronous) {
         ans.stage = 'create'


### PR DESCRIPTION
When we create a Report, and it errors for some reason, we need to see
what was sent in, and this allows us to do that. Maybe it's no big deal,
but it does allow for us to know what was passed in that errored out.